### PR TITLE
feat(ui, i18n): overhaul premium mobile nav and fix localized blog route

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-01-08
+
+### Added
+
+- **feat(nav):** Overhauled the mobile navigation with a premium enterprise design featuring glassmorphism, decorative gradients, and smooth slide-in animations.
+- **feat(nav):** Integrated high-quality icons into the mobile navigation links for improved visual hierarchy.
+- **feat(nav):** Added a fixed "Start Reading" CTA within the mobile menu to drive user engagement.
+
+### Fixed
+
+- **fix(i18n):** Resolved the "double blog" path nesting issue (e.g., `/blog/blog/`) by refining `getStaticPaths` and the `getPostUrl` utility.
+- **fix(i18n):** Implemented hybrid routing: the homepage remains at the root (`/`) while English contents are correctly prefixed with `/en/`.
+- **fix(i18n):** Centralized URL generation across `BlogCard`, `RelatedArticles`, and `BlogPostNavigation` using the updated `getPostUrl` helper.
+- **fix(search):** Synchronized search results to use pre-calculated API URLs, eliminating client-side path reconstruction errors.
+
 ## [1.0.4] - 2026-01-01
 
 ### Added

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -1,6 +1,6 @@
 ---
 import type { CollectionEntry } from "astro:content";
-import { formatDate, useTranslations } from "@/i18n/utils";
+import { formatDate, useTranslations, getLocalizedPath } from "@/i18n/utils";
 import type { ui } from "@/i18n/ui";
 
 export interface Props {
@@ -12,7 +12,7 @@ export interface Props {
 
 const { post, lang, showExcerpt = true, isFeatured = false } = Astro.props;
 const t = useTranslations(lang as keyof typeof ui);
-const postUrl = `/${post.slug}`;
+const postUrl = getLocalizedPath(`/blog/${post.slug.split('/').slice(1).join('/')}`, lang);
 
 const excerpt = showExcerpt
   ? post.data.description || post.body.slice(0, isFeatured ? 300 : 150) + "..."
@@ -55,7 +55,7 @@ const excerptClasses = [
       <a href={postUrl} tabindex="-1" aria-hidden="true">
         <img
           src={post.data.heroImage}
-          alt={post.data.heroAlt || post.data.title}
+          alt={post.data.heroImageAlt || post.data.title}
           width={600}
           height={400}
           class={imageClasses}

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -1,6 +1,6 @@
 ---
 import type { CollectionEntry } from "astro:content";
-import { formatDate, useTranslations, getLocalizedPath } from "@/i18n/utils";
+import { formatDate, useTranslations, getPostUrl } from "@/i18n/utils";
 import type { ui } from "@/i18n/ui";
 
 export interface Props {
@@ -12,7 +12,7 @@ export interface Props {
 
 const { post, lang, showExcerpt = true, isFeatured = false } = Astro.props;
 const t = useTranslations(lang as keyof typeof ui);
-const postUrl = getLocalizedPath(`/blog/${post.slug.split('/').slice(1).join('/')}`, lang);
+const postUrl = getPostUrl(post.slug, lang);
 
 const excerpt = showExcerpt
   ? post.data.description || post.body.slice(0, isFeatured ? 300 : 150) + "..."

--- a/src/components/blog/PostGrid.astro
+++ b/src/components/blog/PostGrid.astro
@@ -1,13 +1,13 @@
 ---
 import BlogCard from "@/components/blog/BlogCard.astro";
-import type { Post } from "@/features/blog/blogData";
+import type { CollectionEntry } from "astro:content";
 import { useTranslations } from "@/i18n/utils";
 import { languages } from "@/i18n/ui";
 
 type LanguageKey = keyof typeof languages;
 
 interface Props {
-  posts: Post[];
+  posts: CollectionEntry<"blog">[];
   lang: LanguageKey;
 }
 

--- a/src/components/blog/RelatedArticles.astro
+++ b/src/components/blog/RelatedArticles.astro
@@ -1,10 +1,11 @@
 ---
 import { getLocalizedPath, useTranslations } from '@/i18n/utils';
 import type { CollectionEntry } from 'astro:content';
+import { ui } from '@/i18n/ui';
 
 interface Props {
   relatedPosts: CollectionEntry<'blog'>[];
-  lang: string;
+  lang: keyof typeof ui;
 }
 
 const { relatedPosts, lang } = Astro.props;
@@ -16,7 +17,7 @@ const t = useTranslations(lang);
     <h2 class="text-2xl font-bold mb-6 text-gray-900 dark:text-gray-100">{t('blog.relatedPosts')}</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
       {relatedPosts.map((post) => (
-        <a href={getLocalizedPath(`/blog/${post.slug.split('/').pop()}`, lang)} class="block group">
+        <a href={getLocalizedPath(`/blog/${post.slug.split('/').slice(1).join('/')}`, lang)} class="block group">
           <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden h-full flex flex-col">
             {post.data.heroImage && (
               <img
@@ -42,4 +43,3 @@ const t = useTranslations(lang);
     </div>
   </section>
 )}
-

--- a/src/components/blog/RelatedArticles.astro
+++ b/src/components/blog/RelatedArticles.astro
@@ -1,5 +1,5 @@
 ---
-import { getLocalizedPath, useTranslations } from '@/i18n/utils';
+import { getPostUrl, useTranslations } from '@/i18n/utils';
 import type { CollectionEntry } from 'astro:content';
 import { ui } from '@/i18n/ui';
 
@@ -17,7 +17,7 @@ const t = useTranslations(lang);
     <h2 class="text-2xl font-bold mb-6 text-gray-900 dark:text-gray-100">{t('blog.relatedPosts')}</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
       {relatedPosts.map((post) => (
-        <a href={getLocalizedPath(`/blog/${post.slug.split('/').slice(1).join('/')}`, lang)} class="block group">
+        <a href={getPostUrl(post.slug, lang)} class="block group">
           <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden h-full flex flex-col">
             {post.data.heroImage && (
               <img

--- a/src/components/blog/ShareButtons.astro
+++ b/src/components/blog/ShareButtons.astro
@@ -51,4 +51,4 @@ const shareLinks = [
       <span class="ml-2 hidden sm:inline">{link.name}</span>
     </a>
   ))}
-</div>
+</section>

--- a/src/components/cards/FeaturedPostCard.astro
+++ b/src/components/cards/FeaturedPostCard.astro
@@ -3,18 +3,18 @@ import type { CollectionEntry } from "astro:content";
 import FeaturedPostImage from "./FeaturedPostCard/FeaturedPostImage.astro";
 import FeaturedPostOverlay from "./FeaturedPostCard/FeaturedPostOverlay.astro";
 import FeaturedPostContent from "./FeaturedPostCard/FeaturedPostContent.astro";
+import { getLangFromUrl, getPostUrl } from "@/i18n/utils";
 
 interface Props {
   post: CollectionEntry<"blog">;
   index: number;
-  authorImage: string;
-  authorSlug: string;
 }
 
-const { post, index, authorImage, authorSlug } = Astro.props;
+const { post, index } = Astro.props;
+const lang = getLangFromUrl(Astro.url);
 
-// Fix double /blog/ issue - post.slug already contains the full path
-const postUrl = `/${post.slug}`;
+// Fix double /blog/ issue - use helper
+const postUrl = getPostUrl(post.slug, lang);
 ---
 
 <article
@@ -30,7 +30,7 @@ const postUrl = `/${post.slug}`;
   <FeaturedPostContent
     post={post}
     index={index}
-    
+    lang={lang}
   />
   <a
     href={postUrl}

--- a/src/components/cards/FeaturedPostCard/FeaturedPostContent.astro
+++ b/src/components/cards/FeaturedPostCard/FeaturedPostContent.astro
@@ -8,11 +8,10 @@ import PostTags from "./PostTags.astro";
 interface Props {
   post: CollectionEntry<"blog">;
   index: number;
-  authorImage: string;
-  authorSlug: string;
+  lang: string;
 }
 
-const { post, index, authorImage, authorSlug } = Astro.props;
+const { post, index, lang } = Astro.props;
 ---
 
 <div
@@ -20,11 +19,12 @@ const { post, index, authorImage, authorSlug } = Astro.props;
   <div class="z-10 space-y-2">
     <PostMeta
       post={post}
-      
+      lang={lang}
     />
     <PostTitle
       post={post}
       index={index}
+      lang={lang}
     />
     <PostDescription
       post={post}

--- a/src/components/cards/FeaturedPostCard/FeaturedPostImage.astro
+++ b/src/components/cards/FeaturedPostCard/FeaturedPostImage.astro
@@ -2,7 +2,7 @@
 import Picture from "@/components/ui/Picture.astro";
 
 interface Props {
-  heroImage: string;
+  heroImage?: string;
   index: number;
 }
 

--- a/src/components/cards/FeaturedPostCard/PostMeta.astro
+++ b/src/components/cards/FeaturedPostCard/PostMeta.astro
@@ -1,14 +1,14 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import Picture from "@/components/ui/Picture.astro";
+import { formatDate } from "@/i18n/utils";
 
 interface Props {
   post: CollectionEntry<"blog">;
-  authorImage: string;
-  authorSlug: string;
+  lang: string;
 }
 
-const { post, authorImage, authorSlug } = Astro.props;
+const { post, lang } = Astro.props;
 ---
 
 <div class="flex items-center gap-3 text-sm text-blue-200 sm:gap-2">
@@ -48,12 +48,6 @@ const { post, authorImage, authorSlug } = Astro.props;
         d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5"
       ></path>
     </svg>
-    {
-      new Date(post.data.pubDate).toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-      })
-    }
+    {formatDate(post.data.pubDate, lang)}
   </time>
 </div>

--- a/src/components/cards/FeaturedPostCard/PostTitle.astro
+++ b/src/components/cards/FeaturedPostCard/PostTitle.astro
@@ -1,12 +1,14 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { getPostUrl } from "@/i18n/utils";
 
 interface Props {
   post: CollectionEntry<"blog">;
   index: number;
+  lang: string;
 }
 
-const { post, index } = Astro.props;
+const { post, index, lang } = Astro.props;
 ---
 
 <h2
@@ -19,7 +21,7 @@ const { post, index } = Astro.props;
   ]}
   aria-level={index === 0 ? 1 : 2}>
   <a
-    href={`/${post.slug}`}
+    href={getPostUrl(post.slug, lang)}
     class="hover:text-primary-200 focus:text-primary-200 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-2 focus:ring-offset-gray-800 transition-colors duration-200 line-clamp-2 sm:line-clamp-none"
     aria-describedby={`featured-post-desc-${post.slug}`}>
     {post.data.title}

--- a/src/components/navigation/HeaderNavLinks.astro
+++ b/src/components/navigation/HeaderNavLinks.astro
@@ -10,8 +10,9 @@ interface NavLink {
     | "nav.services"
     | "nav.about"
     | "nav.contact"
-    | "nav.search"; // More specific type for text keys
-  checkStartsWith?: boolean; // For /blog to match /blog/*
+    | "nav.search";
+  icon: string; // Lucide-inspired SVG path
+  checkStartsWith?: boolean;
 }
 
 interface Props {
@@ -24,11 +25,32 @@ const { lang, currentPath, variant } = Astro.props;
 const t = useTranslations(lang);
 
 const navLinks: NavLink[] = [
-  { href: "/", textKey: "nav.home" },
-  { href: "/blog", textKey: "nav.blog", checkStartsWith: true },
-  { href: "/services", textKey: "nav.services" },
-  { href: "/about", textKey: "nav.about" },
-  { href: "/contact", textKey: "nav.contact" },
+  {
+    href: "/",
+    textKey: "nav.home",
+    icon: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6",
+  },
+  {
+    href: "/blog",
+    textKey: "nav.blog",
+    icon: "M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6m-6 4h10",
+    checkStartsWith: true,
+  },
+  {
+    href: "/services",
+    textKey: "nav.services",
+    icon: "M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z",
+  },
+  {
+    href: "/about",
+    textKey: "nav.about",
+    icon: "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
+  },
+  {
+    href: "/contact",
+    textKey: "nav.contact",
+    icon: "M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z",
+  },
 ];
 
 const underlineBaseClass =
@@ -39,11 +61,11 @@ const activeDesktopClass = "text-blue-600 dark:text-blue-400";
 const inactiveDesktopClass =
   "text-slate-600 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400";
 const baseMobileClass =
-  "px-3 py-2 text-sm font-medium rounded-md transition-colors duration-200";
+  "flex items-center gap-4 px-5 py-4 text-lg font-semibold rounded-2xl transition-all duration-300 group";
 const activeMobileClass =
-  "text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/20";
+  "text-blue-600 dark:text-blue-400 bg-blue-50/80 dark:bg-blue-900/30 backdrop-blur-md shadow-sm ring-1 ring-blue-100 dark:ring-blue-800";
 const inactiveMobileClass =
-  "text-gray-700 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-gray-50 dark:hover:bg-gray-800";
+  "text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/50 hover:text-slate-900 dark:hover:text-white";
 ---
 
 {
@@ -65,12 +87,25 @@ const inactiveMobileClass =
         </a>
       );
     } else {
-      // mobile
+      // mobile - grande & premium
       return (
         <a
           href={localizedHref}
-          class={`${baseMobileClass} ${isActive ? activeMobileClass : inactiveMobileClass}`}>
-          {t(link.textKey as keyof typeof t)}
+          class:list={[
+            baseMobileClass,
+            isActive ? activeMobileClass : inactiveMobileClass,
+          ]}>
+          <div class={`flex items-center justify-center w-11 h-11 rounded-xl shrink-0 transition-all duration-300 ${isActive ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/30' : 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 group-hover:bg-blue-100 dark:group-hover:bg-blue-900/50 group-hover:text-blue-600 dark:group-hover:text-blue-400'}`}>
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={link.icon}></path>
+            </svg>
+          </div>
+          <span class="flex-1 tracking-tight">
+            {t(link.textKey as keyof typeof t)}
+          </span>
+          <svg class={`w-5 h-5 transition-all duration-300 ${isActive ? 'translate-x-0 opacity-100 text-blue-600' : '-translate-x-2 opacity-0 group-hover:translate-x-0 group-hover:opacity-100'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+          </svg>
         </a>
       );
     }

--- a/src/components/navigation/MobileMenu.astro
+++ b/src/components/navigation/MobileMenu.astro
@@ -1,35 +1,42 @@
 ---
 import HeaderNavLinks from "./HeaderNavLinks.astro";
-import { getLangFromUrl } from "@/i18n/utils";
+import { getLangFromUrl, useTranslations, getLocalizedPath } from "@/i18n/utils";
 import type { LanguageKey } from "@/i18n/types";
 
 const lang = getLangFromUrl(Astro.url) as LanguageKey;
 const currentPath = Astro.url.pathname;
+const t = useTranslations(lang);
 ---
 
 <div
   id="mobile-nav-overlay"
-  class="mobile-nav-overlay fixed inset-0 bg-black/50 hidden md:hidden"
+  class="mobile-nav-overlay fixed inset-0 bg-slate-900/40 backdrop-blur-sm z-40 opacity-0 pointer-events-none transition-opacity duration-300 md:hidden"
   aria-hidden="true"
   role="presentation"
 >
 </div>
 <div
   id="mobile-menu"
-  class="fixed top-0 right-0 h-full w-80 bg-white dark:bg-slate-900 z-50 shadow-lg p-6 hidden md:hidden"
+  class="fixed top-0 right-0 h-full w-[85%] max-w-sm bg-white/95 dark:bg-slate-900/95 backdrop-blur-2xl z-50 shadow-2xl translate-x-full transition-transform duration-500 ease-out flex flex-col md:hidden border-l border-white/20 dark:border-slate-800/50"
   aria-modal="true"
   aria-label="Mobile menu"
   role="dialog"
   aria-hidden="true"
 >
-  <div class="flex justify-end mb-4">
+  <!-- Decorative Header Gradient -->
+  <div class="absolute top-0 right-0 -z-10 w-full h-40 bg-gradient-to-br from-blue-600/10 via-indigo-600/5 to-transparent dark:from-blue-500/10 dark:via-indigo-500/5"></div>
+
+  <header class="flex items-center justify-between p-6 border-b border-slate-100 dark:border-slate-800">
+    <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">
+      Navigation
+    </div>
     <button
       id="close-mobile-menu"
-      class="text-gray-600 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 transition-colors duration-200"
+      class="group p-2 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-500 transition-all duration-300"
       aria-label="Close mobile menu"
     >
       <svg
-        class="h-6 w-6"
+        class="h-6 w-6 transform group-hover:rotate-90 transition-transform duration-300"
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
@@ -43,10 +50,23 @@ const currentPath = Astro.url.pathname;
         ></path>
       </svg>
     </button>
-  </div>
-  <div class="flex flex-col gap-4">
+  </header>
+
+  <nav class="flex-1 overflow-y-auto p-6 flex flex-col gap-2">
     <HeaderNavLinks lang={lang} currentPath={currentPath} variant="mobile" />
-  </div>
+  </nav>
+
+  <footer class="p-6 border-t border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
+    <a
+      href={getLocalizedPath("/blog", lang)}
+      class="flex items-center justify-center gap-3 w-full py-4 text-center font-bold text-white bg-gradient-to-r from-blue-600 to-indigo-600 rounded-2xl shadow-xl shadow-blue-500/20 hover:shadow-blue-500/40 hover:scale-[1.02] active:scale-95 transition-all duration-300"
+    >
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+      </svg>
+      {t("home.hero.startReading")}
+    </a>
+  </footer>
 </div>
 
 <script>
@@ -61,9 +81,10 @@ const currentPath = Astro.url.pathname;
     const openMobileMenu = () => {
       if (!mobileMenu || !mobileNavOverlay) return;
       lastActiveElement = document.activeElement as HTMLElement | null;
-      mobileMenu.classList.remove("hidden");
-      mobileNavOverlay.classList.remove("hidden");
-      mobileNavOverlay.setAttribute("aria-hidden", "false");
+      mobileMenu.classList.remove("translate-x-full");
+      mobileNavOverlay.classList.remove("pointer-events-none");
+      mobileNavOverlay.classList.add("opacity-100");
+
       document.body.classList.add("mobile-nav-open");
       mobileMenu.setAttribute("aria-hidden", "false");
       if (mobileMenuButton) {
@@ -98,8 +119,10 @@ const currentPath = Astro.url.pathname;
     const closeMobileMenu = () => {
       if (!mobileMenu || !mobileNavOverlay) return;
       document.body.classList.remove("mobile-nav-open");
-      mobileMenu.classList.add("hidden");
-      mobileNavOverlay.classList.add("hidden");
+      mobileMenu.classList.add("translate-x-full");
+      mobileNavOverlay.classList.add("pointer-events-none");
+      mobileNavOverlay.classList.remove("opacity-100");
+
       mobileMenu.setAttribute("aria-hidden", "true");
       mobileNavOverlay.setAttribute("aria-hidden", "true");
       if (mobileMenuButton) {
@@ -123,9 +146,14 @@ const currentPath = Astro.url.pathname;
     }
 
     document.addEventListener("keydown", (event) => {
-      if (event.key === "Escape" && mobileMenu && !mobileMenu.classList.contains("hidden")) {
+      if (event.key === "Escape" && mobileMenu && !mobileMenu.classList.contains("translate-x-full")) {
         closeMobileMenu();
       }
+    });
+
+    // Close menu when clicking a link
+    mobileMenu?.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', closeMobileMenu);
     });
   });
 </script>

--- a/src/components/search/enhancedSearchClient.ts
+++ b/src/components/search/enhancedSearchClient.ts
@@ -186,7 +186,7 @@ class EnhancedSearchUI {
     const pubDate = new Date(result.pubDate).toLocaleDateString();
 
     return `
-      <div class="search-result-item p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all duration-200 cursor-pointer" data-index="${index}" data-url="${result.lang === 'en' ? '' : '/' + result.lang}/blog/${result.slug}">
+      <div class="search-result-item p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all duration-200 cursor-pointer" data-index="${index}" data-url="${result.url}">
         <div class="flex items-start space-x-4">
           <div class="flex-shrink-0">
             <div class="w-16 h-16 bg-gradient-to-br from-primary-400 to-primary-600 rounded-lg flex items-center justify-center">

--- a/src/components/search/enhancedSearchClient.ts
+++ b/src/components/search/enhancedSearchClient.ts
@@ -1,7 +1,7 @@
-import EnterpriseSearchEngine, { 
-  type SearchResult, 
-  type SearchFilters, 
-  type SearchSuggestion 
+import EnterpriseSearchEngine, {
+  type SearchResult,
+  type SearchFilters,
+  type SearchSuggestion
 } from '../../features/search/EnterpriseSearchEngine';
 
 interface CategoryInfo {
@@ -78,7 +78,7 @@ class EnhancedSearchUI {
       this.allDocuments = await response.json();
       this.searchEngine.indexDocuments(this.allDocuments);
       console.log(`Enhanced search engine initialized with ${this.allDocuments.length} documents.`);
-      
+
       // Initialize suggestions
       this.initializeSuggestions();
     } catch (error) {
@@ -95,7 +95,7 @@ class EnhancedSearchUI {
     // Overlay controls
     const openButton = document.getElementById('open-search-overlay');
     const closeButton = document.getElementById('close-search-overlay');
-    
+
     openButton?.addEventListener('click', () => this.openSearchOverlay());
     closeButton?.addEventListener('click', () => this.closeSearchOverlay());
 
@@ -168,7 +168,7 @@ class EnhancedSearchUI {
     this.updateFilters(results);
 
     // Display results
-    this.searchResultsContainer.innerHTML = results.map((result, index) => 
+    this.searchResultsContainer.innerHTML = results.map((result, index) =>
       this.createResultCard(result, index)
     ).join('');
 
@@ -177,7 +177,7 @@ class EnhancedSearchUI {
   }
 
   private createResultCard(result: SearchResult, index: number): string {
-    const tags = result.tags.slice(0, 3).map(tag => 
+    const tags = result.tags.slice(0, 3).map(tag =>
       `<span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">${tag}</span>`
     ).join('');
 
@@ -186,7 +186,7 @@ class EnhancedSearchUI {
     const pubDate = new Date(result.pubDate).toLocaleDateString();
 
     return `
-      <div class="search-result-item p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all duration-200 cursor-pointer" data-index="${index}" data-url="/${result.lang}/blog/${result.slug}">
+      <div class="search-result-item p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all duration-200 cursor-pointer" data-index="${index}" data-url="${result.lang === 'en' ? '' : '/' + result.lang}/blog/${result.slug}">
         <div class="flex items-start space-x-4">
           <div class="flex-shrink-0">
             <div class="w-16 h-16 bg-gradient-to-br from-primary-400 to-primary-600 rounded-lg flex items-center justify-center">
@@ -235,14 +235,14 @@ class EnhancedSearchUI {
 
   private updateFilters(results: SearchResult[]): void {
     const categories = new Map<string, number>();
-    
+
     results.forEach(result => {
       if (result.category) {
         categories.set(result.category, (categories.get(result.category) || 0) + 1);
       }
     });
 
-    const filterButtons = Array.from(categories.entries()).map(([category, count]) => 
+    const filterButtons = Array.from(categories.entries()).map(([category, count]) =>
       `<button class="filter-btn px-3 py-1 text-sm rounded-full border border-gray-300 dark:border-gray-600 hover:border-primary-500 dark:hover:border-primary-400 transition-colors" data-filter="category" data-value="${category}">
         ${category} (${count})
       </button>`
@@ -288,8 +288,8 @@ class EnhancedSearchUI {
     // Show fallback suggestions
     const suggestions = this.searchEngine.getSuggestions(query, 5);
     const fallbackContainer = document.getElementById('search-suggestions-fallback')!;
-    
-    fallbackContainer.innerHTML = suggestions.map(suggestion => 
+
+    fallbackContainer.innerHTML = suggestions.map(suggestion =>
       `<button class="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-700 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors" onclick="document.getElementById('search-input').value='${suggestion.text}'; document.getElementById('search-input').dispatchEvent(new Event('input'));">
         ${suggestion.text}
       </button>`
@@ -311,7 +311,7 @@ class EnhancedSearchUI {
 
     // Populate categories
     const categoriesContainer = document.getElementById('categories-list')!;
-    categoriesContainer.innerHTML = categories.map(cat => 
+    categoriesContainer.innerHTML = categories.map(cat =>
       `<button class="suggestion-item px-3 py-1 text-sm rounded-full transition-colors ${cat.color}" onclick="document.getElementById('search-input').value='category:${cat.name}'; document.getElementById('search-input').dispatchEvent(new Event('input'));">
         ${cat.name} (${cat.count})
       </button>`
@@ -319,7 +319,7 @@ class EnhancedSearchUI {
 
     // Populate tags
     const tagsContainer = document.getElementById('tags-list')!;
-    tagsContainer.innerHTML = tags.slice(0, 10).map(tag => 
+    tagsContainer.innerHTML = tags.slice(0, 10).map(tag =>
       `<button class="suggestion-item px-3 py-1 text-sm rounded-full transition-colors ${tag.color}" onclick="document.getElementById('search-input').value='${tag.name}'; document.getElementById('search-input').dispatchEvent(new Event('input'));">
         # ${tag.name}
       </button>`
@@ -327,7 +327,7 @@ class EnhancedSearchUI {
 
     // Populate authors
     const authorsContainer = document.getElementById('authors-list')!;
-    authorsContainer.innerHTML = authors.map(author => 
+    authorsContainer.innerHTML = authors.map(author =>
       `<button class="suggestion-item px-3 py-1 text-sm bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200 rounded-full hover:bg-purple-200 dark:hover:bg-purple-800 transition-colors" onclick="document.getElementById('search-input').value='author:${author.name}'; document.getElementById('search-input').dispatchEvent(new Event('input'));">
         ${author.name}
       </button>`
@@ -335,7 +335,7 @@ class EnhancedSearchUI {
 
     // Populate popular searches
     const popularContainer = document.getElementById('popular-searches-list')!;
-    popularContainer.innerHTML = popularSearches.map(search => 
+    popularContainer.innerHTML = popularSearches.map(search =>
       `<button class="suggestion-item flex items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors w-full text-left" onclick="document.getElementById('search-input').value='${search.query}'; document.getElementById('search-input').dispatchEvent(new Event('input'));">
         <svg class="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
@@ -411,7 +411,7 @@ class EnhancedSearchUI {
 
   private handleKeyboardNavigation(e: KeyboardEvent): void {
     const visibleResults = this.searchResultsContainer.querySelectorAll('.search-result-item');
-    
+
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault();
@@ -472,7 +472,7 @@ class EnhancedSearchUI {
     this.searchOverlay.setAttribute('aria-hidden', 'false');
     this.searchInput.focus();
     document.body.style.overflow = 'hidden';
-    
+
     if (this.currentQuery.length === 0) {
       this.showSuggestions();
     }
@@ -485,7 +485,7 @@ class EnhancedSearchUI {
     this.currentQuery = '';
     this.keyboardFocusIndex = -1;
     document.body.style.overflow = '';
-    
+
     // Clear results and show suggestions
     this.showSuggestions();
     this.searchResultsContainer.innerHTML = '';
@@ -499,4 +499,3 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // Export for potential external use
 export default EnhancedSearchUI;
-

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -21,6 +21,7 @@ const blog = defineCollection({
     comment: z.boolean().optional(),
     robots: z.string().trim().optional(),
     canonicalURL: z.string().trim().optional(),
+    readingTime: z.string().optional(),
   }),
 });
 

--- a/src/features/blog/blogData.ts
+++ b/src/features/blog/blogData.ts
@@ -1,26 +1,7 @@
 import { getCollection, type CollectionEntry } from "astro:content";
 
 // Define a type for a blog post for better type safety
-export interface Post {
-  id: string;
-  slug: string;
-  body: string;
-  collection: "blog";
-  data: {
-    title: string;
-    description: string;
-    pubDate: Date;
-    updatedDate?: Date;
-    heroImage?: string;
-    tags?: string[];
-    draft?: boolean;
-  };
-  render: () => Promise<{
-    Content: unknown;
-    headings: { depth: number; slug: string; text: string }[];
-    remarkPluginFrontmatter: Record<string, unknown>;
-  }>;
-}
+export type Post = CollectionEntry<"blog">;
 
 /**
  * Fetches all English blog posts, filters out drafts, and sorts them by publication date.

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -37,6 +37,7 @@ export const ui = {
     "blog.description":
       "Discover insights, tutorials, and stories from our community of developers and creators.",
     "blog.readMore": "Read more",
+    "blog.readMoreAbout": "Read more about",
     "blog.readTime": "min read",
     "blog.publishedOn": "Published on",
     "blog.by": "by",
@@ -173,6 +174,7 @@ export const ui = {
     "blog.description":
       "Descubre perspectivas, tutoriales e historias de nuestra comunidad de desarrolladores y creadores.",
     "blog.readMore": "Leer más",
+    "blog.readMoreAbout": "Leer más sobre",
     "blog.readTime": "min de lectura",
     "blog.publishedOn": "Publicado el",
     "blog.by": "por",
@@ -310,6 +312,7 @@ export const ui = {
     "blog.description":
       "開発者とクリエイターのコミュニティからの洞察、チュートリアル、ストーリーを発見。",
     "blog.readMore": "続きを読む",
+    "blog.readMoreAbout": "詳細を読む:",
     "blog.readTime": "分で読める",
     "blog.publishedOn": "公開日",
     "blog.by": "著者",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -15,14 +15,14 @@ export function useTranslations(lang: keyof typeof ui) {
 
 export function getLocalizedPath(path: string, lang: string) {
   if (lang === defaultLang) {
-    if (path === "/") {
-      return "/";
-    } else {
-      return `/${lang}${path}`;
-    }
-  } else {
-    return `/${lang}${path}`;
+    return path;
   }
+  return `/${lang}${path.startsWith('/') ? path : '/' + path}`;
+}
+
+export function getPostUrl(slug: string, lang: string) {
+  const slugWithoutLang = slug.split('/').slice(1).join('/');
+  return getLocalizedPath(`/blog/${slugWithoutLang}`, lang);
 }
 
 export function removeLocaleFromPath(path: string) {

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -14,15 +14,25 @@ export function useTranslations(lang: keyof typeof ui) {
 }
 
 export function getLocalizedPath(path: string, lang: string) {
-  if (lang === defaultLang) {
-    return path;
+  // Special case: English home page stays at root
+  if (lang === 'en' && (path === '/' || path === '')) {
+    return '/';
   }
-  return `/${lang}${path.startsWith('/') ? path : '/' + path}`;
+  const cleanPath = path.startsWith('/') ? path : '/' + path;
+  return `/${lang}${cleanPath}`;
 }
 
 export function getPostUrl(slug: string, lang: string) {
-  const slugWithoutLang = slug.split('/').slice(1).join('/');
-  return getLocalizedPath(`/blog/${slugWithoutLang}`, lang);
+  // slug usually is "lang/slug-content" or "lang/blog/slug-content"
+  const parts = slug.split('/');
+  const slugWithoutLang = parts.slice(1).join('/');
+
+  // Check if the slug already includes the 'blog' segment to avoid double /blog/blog/
+  const path = slugWithoutLang.startsWith('blog/')
+    ? `/${slugWithoutLang}`
+    : `/blog/${slugWithoutLang}`;
+
+  return getLocalizedPath(path, lang);
 }
 
 export function removeLocaleFromPath(path: string) {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -37,7 +37,7 @@ let nextPostData: { url: string; title: string } | undefined = undefined;
 if (currentIndex !== -1) {
   if (currentIndex > 0) {
     const prev = sortedLangPosts[currentIndex - 1];
-    const prevSlugWithoutLang = prev.slug.replace(/^(en|es|ja)\/blog\//g, '');
+    const prevSlugWithoutLang = prev.slug.split('/').slice(1).join('/');
     const prevUrl = getLocalizedPath(`/blog/${prevSlugWithoutLang}`, lang);
     previousPostData = {
       url: prevUrl,
@@ -46,7 +46,7 @@ if (currentIndex !== -1) {
   }
   if (currentIndex < sortedLangPosts.length - 1) {
     const next = sortedLangPosts[currentIndex + 1];
-    const nextSlugWithoutLang = next.slug.replace(/^(en|es|ja)\/blog\//g, '');
+    const nextSlugWithoutLang = next.slug.split('/').slice(1).join('/');
     const nextUrl = getLocalizedPath(`/blog/${nextSlugWithoutLang}`, lang);
     nextPostData = {
       url: nextUrl,
@@ -119,7 +119,7 @@ const relatedPosts = allLangPosts
           <div class="mb-8 rounded-lg overflow-hidden">
             <Picture
               src={heroImage}
-              alt={title}
+              alt={heroImageAlt || title}
               width={1200}
               height={600}
               class="w-full h-64 sm:h-80 lg:h-96 object-cover"

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,7 +4,7 @@ import Layout from './Layout.astro';
 import Picture from '@/components/ui/Picture.astro';
 import BlogPostNavigation from '@/components/navigation/BlogPostNavigation.astro';
 import ShareButtons from '@/components/blog/ShareButtons.astro';
-import { formatDate, getLangFromUrl, useTranslations, getLocalizedPath } from '@/i18n/utils';
+import { formatDate, getLangFromUrl, useTranslations, getLocalizedPath, getPostUrl } from '@/i18n/utils';
 import RelatedArticles from '@/components/blog/RelatedArticles.astro';
 import TableOfContents from '@/components/blog/TableOfContents.astro';
 
@@ -37,19 +37,15 @@ let nextPostData: { url: string; title: string } | undefined = undefined;
 if (currentIndex !== -1) {
   if (currentIndex > 0) {
     const prev = sortedLangPosts[currentIndex - 1];
-    const prevSlugWithoutLang = prev.slug.split('/').slice(1).join('/');
-    const prevUrl = getLocalizedPath(`/blog/${prevSlugWithoutLang}`, lang);
     previousPostData = {
-      url: prevUrl,
+      url: getPostUrl(prev.slug, lang),
       title: prev.data.title,
     };
   }
   if (currentIndex < sortedLangPosts.length - 1) {
     const next = sortedLangPosts[currentIndex + 1];
-    const nextSlugWithoutLang = next.slug.split('/').slice(1).join('/');
-    const nextUrl = getLocalizedPath(`/blog/${nextSlugWithoutLang}`, lang);
     nextPostData = {
-      url: nextUrl,
+      url: getPostUrl(next.slug, lang),
       title: next.data.title,
     };
   }

--- a/src/pages/api/get-posts.astro
+++ b/src/pages/api/get-posts.astro
@@ -1,10 +1,8 @@
 ---
 import { getCollection, type CollectionEntry } from 'astro:content';
-import BlogCard from '@/components/blog/BlogCard.astro';
+import { getPostUrl } from '@/i18n/utils';
 
-import { getCollection, type CollectionEntry } from 'astro:content';
-
-export async function get({ request }: { request: Request }) {
+export const GET = async ({ request }: { request: Request }) => {
   try {
     const url = new URL(request.url);
     const page = parseInt(url.searchParams.get('page') || '1', 10);
@@ -26,7 +24,7 @@ export async function get({ request }: { request: Request }) {
     const postsToDisplay = sortedPosts.slice(startIndex, startIndex + postsPerPage);
 
     const postsData = postsToDisplay.map(post => ({
-      url: `/${post.slug.replace(/^(en\/)?/, '')}`,
+      url: getPostUrl(post.slug, lang),
       title: post.data.title,
       description: post.data.description,
       pubDate: post.data.pubDate,
@@ -37,6 +35,7 @@ export async function get({ request }: { request: Request }) {
     }));
 
     return new Response(JSON.stringify(postsData), {
+      status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {

--- a/src/pages/api/search-index.ts
+++ b/src/pages/api/search-index.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
+import { getPostUrl } from "@/i18n/utils";
 import EnterpriseSearchEngine from "../../features/search/EnterpriseSearchEngine";
 
 export const GET: APIRoute = async () => {
@@ -8,18 +9,21 @@ export const GET: APIRoute = async () => {
       return !data.draft;
     });
 
-    const documents = allBlogPosts.map((post) => ({
-      id: post.id,
-      title: post.data.title,
-      description: post.data.description,
-      content: post.body,
-      tags: post.data.tags || [],
-      url: `/${post.slug}`,
-      pubDate: post.data.pubDate,
-      author: post.data.author,
-      lang: post.slug.split('/')[0], // Assuming slug format like 'en/blog/post-title'
-      slug: post.slug.split('/').slice(2).join('/'), // Get everything after 'en/blog/'
-    }));
+    const documents = allBlogPosts.map((post) => {
+      const lang = post.slug.split('/')[0];
+      return {
+        id: post.id,
+        title: post.data.title,
+        description: post.data.description,
+        content: post.body,
+        tags: post.data.tags || [],
+        url: getPostUrl(post.slug, lang),
+        pubDate: post.data.pubDate,
+        author: post.data.author,
+        lang: lang,
+        slug: post.slug.split('/').slice(1).join('/'),
+      };
+    });
 
     const searchEngine = new EnterpriseSearchEngine();
     searchEngine.indexDocuments(documents);

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -15,34 +15,26 @@ interface StaticPath {
 }
 
 export async function getStaticPaths() {
-  const allPosts = await getCollection('blog', ({ id, data }: { id: string, data: any }) => !id.startsWith('en/') && !data.draft);
+  const allPosts = await getCollection('blog', ({ id, data }: { id: string, data: any }) => id.startsWith('en/') && !data.draft);
 
-  const paths: StaticPath[] = [];
-
-  // Generate paths for all languages
-  allPosts.forEach((post: CollectionEntry<'blog'>) => {
+  return allPosts.map((post: CollectionEntry<'blog'>) => {
     const parts = post.id.split('/');
-    const lang = parts[0];
+    // parts[0] is 'en', parts[1] is 'blog' or the actual slug
     const slugPart = parts[1] === 'blog' ? parts.slice(2).join('/') : parts.slice(1).join('/');
-
-    // Remove the file extension (.mdx or .md) from the slug part
     const finalSlug = slugPart.replace(/\.(mdx?)$/, '');
 
-    paths.push({
+    return {
       params: {
-        lang: lang,
-        slug: finalSlug // Use the carefully constructed slug
+        slug: finalSlug
       },
       props: post,
-    });
+    };
   });
-
-  return paths;
 }
 
 type Props = CollectionEntry<'blog'>;
 
-const { lang } = Astro.params;
+const lang = "en";
 
 // Validate language
 if (!lang || !isValidLanguage(lang)) {

--- a/src/pages/en/blog/index.astro
+++ b/src/pages/en/blog/index.astro
@@ -4,14 +4,7 @@ import Layout from '@/layouts/Layout.astro';
 import BlogCard from '@/components/blog/BlogCard.astro';
 import { useTranslations, isValidLanguage, getLocalizedPath } from '@/i18n/utils';
 
-export async function getStaticPaths() {
-  return [
-    { params: { lang: "es" } },
-    { params: { lang: "ja" } }
-  ];
-}
-
-const { lang } = Astro.params;
+const lang = "en";
 
 // Validate language
 if (!lang || !isValidLanguage(lang)) {

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -2,6 +2,7 @@ import type { APIContext } from "astro";
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import { getPostUrl } from "@/i18n/utils";
 
 export async function GET(context: APIContext) {
   const posts = await getCollection('blog');
@@ -9,11 +10,14 @@ export async function GET(context: APIContext) {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     site: context.site || 'https://example.com', // Provide a default or handle undefined
-    items: posts.map((post) => ({
-      title: post.data.title,
-      pubDate: post.data.pubDate,
-      description: post.data.description,
-      link: `/${post.slug}/`, // Corrected link
-    })),
+    items: posts.map((post) => {
+      const lang = post.slug.split('/')[0];
+      return {
+        title: post.data.title,
+        pubDate: post.data.pubDate,
+        description: post.data.description,
+        link: getPostUrl(post.slug, lang),
+      };
+    }),
   });
 }


### PR DESCRIPTION
## [1.0.5] - 2026-01-08

### Added

- **feat(nav):** Overhauled the mobile navigation with a premium enterprise design featuring glassmorphism, decorative gradients, and smooth slide-in animations.
- **feat(nav):** Integrated high-quality icons into the mobile navigation links for improved visual hierarchy.
- **feat(nav):** Added a fixed "Start Reading" CTA within the mobile menu to drive user engagement.

### Fixed

- **fix(i18n):** Resolved the "double blog" path nesting issue (e.g., `/blog/blog/`) by refining `getStaticPaths` and the `getPostUrl` utility.
- **fix(i18n):** Implemented hybrid routing: the homepage remains at the root (`/`) while English contents are correctly prefixed with `/en/`.
- **fix(i18n):** Centralized URL generation across `BlogCard`, `RelatedArticles`, and `BlogPostNavigation` using the updated `getPostUrl` helper.
- **fix(search):** Synchronized search results to use pre-calculated API URLs, eliminating client-side path reconstruction errors.